### PR TITLE
feat: middleware centralizado de tratamento de erros e 404

### DIFF
--- a/backend/src/middleware/error-handler.js
+++ b/backend/src/middleware/error-handler.js
@@ -1,0 +1,44 @@
+/**
+ * Middleware de rota não encontrada (404).
+ * Deve ser registrado após todas as rotas.
+ */
+const notFoundHandler = (req, res, _next) => {
+  res.status(404).json({
+    error: {
+      status: 404,
+      message: `Rota não encontrada: ${req.method} ${req.originalUrl}`,
+    },
+  });
+};
+
+/**
+ * Middleware centralizado de tratamento de erros.
+ * Padroniza respostas de erro e oculta stack traces em produção.
+ */
+const errorHandler = (err, _req, res, _next) => {
+  const status = err.status || err.statusCode || 500;
+  const isProduction = process.env.NODE_ENV === "production";
+
+  const response = {
+    error: {
+      status,
+      message:
+        status === 500 && isProduction
+          ? "Erro interno do servidor"
+          : err.message || "Erro interno do servidor",
+    },
+  };
+
+  // Inclui stack trace apenas em desenvolvimento
+  if (!isProduction) {
+    response.error.stack = err.stack;
+  }
+
+  if (status >= 500) {
+    console.error(`[ERRO ${status}]`, err);
+  }
+
+  res.status(status).json(response);
+};
+
+module.exports = { notFoundHandler, errorHandler };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,9 @@
-const express = require('express');
-const cors = require('cors');
-const compression = require('compression');
-require('dotenv').config();
+const express = require("express");
+const cors = require("cors");
+const compression = require("compression");
+require("dotenv").config();
+
+const { notFoundHandler, errorHandler } = require("./middleware/error-handler");
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -12,11 +14,17 @@ app.use(compression());
 app.use(express.json());
 
 // Rota de health check
-app.get('/health', (req, res) => {
-  res.json({ status: 'ok' });
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
 });
 
 // TODO: registrar rotas (auth, products, reviews)
+
+// Middleware de rota não encontrada (deve vir após todas as rotas)
+app.use(notFoundHandler);
+
+// Middleware centralizado de tratamento de erros (deve ser o último)
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Servidor rodando na porta ${PORT}`);


### PR DESCRIPTION
## Descrição

Adiciona middleware centralizado de tratamento de erros ao backend, conforme previsto na stack tecnológica do projeto.

### Alterações

- **`backend/src/middleware/error-handler.js`** (novo): middleware `notFoundHandler` (404) e `errorHandler` (erros gerais)
- **`backend/src/server.js`**: registra os middlewares após as rotas

### Comportamento

- Respostas de erro padronizadas em JSON
- Stack traces ocultos em produção (`NODE_ENV=production`)
- Erros 500+ logados no console
- Rota inexistente retorna 404 com método e path tentados